### PR TITLE
Fix spaniel import for embroider builds

### DIFF
--- a/addon/initializers/spaniel.js
+++ b/addon/initializers/spaniel.js
@@ -1,4 +1,4 @@
-import spaniel from 'spaniel';
+import * as spaniel from 'spaniel';
 import emberSpanielEngine from './../spaniel-engines/ember-spaniel-engine';
 
 export function initialize() {


### PR DESCRIPTION
The default export and the namespace export don't really mean the same thing. Old compatibility code in ember-cli unfortunately allowed this incorrect behavior, while embroider does not. This change is backwards compatible.