### PR TITLE
Support native intersection observer feature flag

### DIFF
--- a/addon/services/viewport.js
+++ b/addon/services/viewport.js
@@ -40,7 +40,7 @@ export default Service.extend({
     });
   },
 
-  getWatcher(root = window, ALLOW_CACHED_SCHEDULER = true) {
+  getWatcher(root = document, ALLOW_CACHED_SCHEDULER = true) {
     let {
       watcherTime: time,
       watcherRatio: ratio,
@@ -80,7 +80,7 @@ export default Service.extend({
     context,
     rootMargin,
     ratio,
-    root = window,
+    root = document,
     ALLOW_CACHED_SCHEDULER = true
   } = {}) {
     const canUseGlobalWatcher = !(rootMargin || ratio || (root !== window));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "calculate-cache-key-for-tree": "^1.1.0",
     "ember-cli-babel": "^7.7.3",
     "ember-rollup": "^2.1.2",
-    "spaniel": "2.5.11"
+    "spaniel": "~2.6.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7837,10 +7837,10 @@ sourcemap-validator@^1.1.0:
     lodash.template "~2.3.x"
     source-map "~0.1.x"
 
-spaniel@2.5.11:
-  version "2.5.11"
-  resolved "https://registry.yarnpkg.com/spaniel/-/spaniel-2.5.11.tgz#067342f7a4779935cbae79395a14a3496f4bd040"
-  integrity sha512-8EQIhAFN9AJEfdGf718vWtoBP7vUziW4A+R+xbQolowuYZoWXADH730Vq9W8bO0LwgYVwcc9XS0eHiUr3wjsSA==
+spaniel@~2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/spaniel/-/spaniel-2.6.3.tgz#4f1f6eb109fcfdc74e743580077123f4a6f5e636"
+  integrity sha512-V/6Aqk4thxsT0zLSerpzYQxFYbY4QmfbcRaPhlUiO2TuyvgH0GadjkEl6OSt5Utd4C3XRyYvbCdc3Z9DjQRaEg==
 
 spawn-args@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
`window` is not a valid root element, but was allowed by spaniel intersection polyfill